### PR TITLE
Set go version in go.mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Requirements
 ------------
 
 - [Terraform](https://www.terraform.io/downloads.html) 0.12.x
-- [Go](https://golang.org/doc/install) 1.11 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) 1.13+ (to build the provider plugin)
 
 Building The Provider
 ---------------------
@@ -33,7 +33,7 @@ Developing the Provider
 -----------------------
 
 If you wish to work on the provider, you'll first need [Go](http://www.golang.org)
-installed on your machine (version 1.11+ is *required*).
+installed on your machine (version 1.13+ is *required*).
 To compile the provider, run:
 
 ```sh

--- a/get-token/go.mod
+++ b/get-token/go.mod
@@ -1,5 +1,7 @@
 module github.com/vpsfreecz/terraform-provider-vpsadmin/get-token
 
+go 1.13
+
 require (
 	github.com/vpsfreecz/vpsadmin-go-client v0.0.0-20200313072921-575ba716cf27
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/vpsfreecz/terraform-provider-vpsadmin
 
+go 1.13
+
 require (
 	github.com/hashicorp/terraform v0.12.0
 	github.com/vpsfreecz/vpsadmin-go-client v0.0.0-20200313072921-575ba716cf27


### PR DESCRIPTION
Newer go versions automatically modify the go.mod, making it annoying to
work with. Since readme states that 1.11+ is required, set the version
to 1.11.